### PR TITLE
make "Empty" in dropdowns grey

### DIFF
--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -225,7 +225,10 @@ export function Select({
             },
           })}
           type="search"
-          className="w-full h-full px-3 pr-10 bg-transparent border-none outline-none text-text-1 placeholder:text-text-2 focus:outline-none focus:ring-1 transition-colors focus:ring-text-3"
+          className={mergeClass(
+            'w-full h-full px-3 pr-10 bg-transparent border-none outline-none placeholder:text-text-2 focus:outline-none focus:ring-1 transition-colors focus:ring-text-3',
+            selectedItem?.label === 'Empty' ? 'text-text-2' : 'text-text-1',
+          )}
           placeholder={placeholder}
           data-lpignore="true"
           autoComplete="off"


### PR DESCRIPTION
Any dropdowns that display "Empty" will be colored grey for nicer readability

<img width="1571" height="182" alt="image" src="https://github.com/user-attachments/assets/ec54f62a-6cd9-455f-aa4c-d88fccc4d7ff" />

(Note that it just checks for the string "Empty" and not if it's the EMPTY index)