### PR TITLE
Fix a mistake in the description for Chapter 4's "Blood stain" flag

### DIFF
--- a/src/data/flags.ts
+++ b/src/data/flags.ts
@@ -5384,7 +5384,7 @@ export const FLAGS_META: Partial<Record<FlagIndex, FlagProperties>> = {
   },
   [FLAGS.CLEANED_UP_BLOOD_STAIN]: {
     displayName: 'Blood stain',
-    description: "Whether the blood stain was cleaned in Noelle's house.",
+    description: "Whether the blood stain was cleaned in Kris's room.",
     valueType: 'boolean',
   },
   [FLAGS.TEXT_FLAG_750]: {


### PR DESCRIPTION
Previously, the description for global event flag `748` described the stain as being in "Noelle's house".

The only place in the game's scripts where flag `748` is set is in an optional bit of dialogue in Kris's room, early into the chapter; by the time you enter Noelle's house, you've already locked yourself out of triggering this flag.