### PR TITLE
sort flag IDs by ascending order

### DIFF
--- a/src/pages/Flags/Root.tsx
+++ b/src/pages/Flags/Root.tsx
@@ -81,13 +81,12 @@ export function FlagsRoot() {
     [debouncedSearchQuery],
   );
 
-  const filteredFlags = useMemo(() => {
-    if (!normalizedSearchQuery) return allFlags;
-
-    return allFlags.filter((flag) =>
-      flag.searchText.includes(normalizedSearchQuery),
-    );
-  }, [allFlags, normalizedSearchQuery]);
+  const filteredFlags = useMemo(
+    () => allFlags
+      .filter((flag) => flag.searchText.includes(normalizedSearchQuery))
+      .sort((a, b) => a.index - b.index),
+    [allFlags, normalizedSearchQuery],
+  );
 
   const totalPages = Math.ceil(filteredFlags.length / itemsPerPage);
   const startIndex = (currentPage - 1) * itemsPerPage;


### PR DESCRIPTION
I think this makes browsing and editing flags a bit easier (smallest ID at the top)