### PR TITLE
Show flag number in help popups

### DIFF
--- a/src/components/FieldWrapper.tsx
+++ b/src/components/FieldWrapper.tsx
@@ -10,6 +10,7 @@ interface FieldWrapperProps {
   id?: string;
   title?: string;
   description?: string;
+  flag?: number;
   className?: string | undefined;
   inline?: boolean;
   label?: boolean;
@@ -28,11 +29,20 @@ export function FieldWrapper({
   id,
   title,
   description,
+  flag,
   className,
   children,
   inline = false,
   label = false,
 }: FieldWrapperProps) {
+  const flagTag =
+    flag !== undefined ? (
+      <span className="font-mono text-sm font-normal text-text-3">
+        <span className="select-none">#</span>
+        <span className="select-all">{flag}</span>
+      </span>
+    ) : undefined;
+
   return (
     <Section id={id} className={mergeClass('flex flex-col gap-2', className)}>
       <InlineGroup>
@@ -43,7 +53,9 @@ export function FieldWrapper({
           </TextLabel>
         )}
         {description && (
-          <HelpTip title={title}>{renderMaybeMarkdown(description)}</HelpTip>
+          <HelpTip title={title} titleExtra={flagTag}>
+            {renderMaybeMarkdown(description)}
+          </HelpTip>
         )}
       </InlineGroup>
 

--- a/src/components/Fields/FlagField.tsx
+++ b/src/components/Fields/FlagField.tsx
@@ -124,7 +124,9 @@ export function FlagField(props: FlagFieldProps) {
       <FieldWrapper
         id={id}
         className={className}
+        title={displayName}
         description={description}
+        flag={sourceFlag}
         inline
       >
         <Checkbox
@@ -149,6 +151,7 @@ export function FlagField(props: FlagFieldProps) {
         className={className}
         title={displayName}
         description={description}
+        flag={sourceFlag}
         value={(currentValue as number) ?? 0}
         placeholder={t('ui.flag.numberPlaceholder', 'Enter number...')}
         min={valueRules?.min ?? 0}
@@ -182,6 +185,7 @@ export function FlagField(props: FlagFieldProps) {
           className={className}
           description={description}
           title={displayName}
+          flag={sourceFlag}
           label
         >
           <Select
@@ -209,6 +213,7 @@ export function FlagField(props: FlagFieldProps) {
         className={mergeClass('gap-3', className)}
         description={description}
         title={displayName}
+        flag={sourceFlag}
         label
       >
         <div className="flex flex-wrap">

--- a/src/components/HelpTip.tsx
+++ b/src/components/HelpTip.tsx
@@ -5,10 +5,11 @@ import { useTranslation } from '../i18n';
 
 interface HelpTipProps {
   title?: string;
+  titleExtra?: ReactNode;
   children?: ReactNode;
 }
 
-export function HelpTip({ title, children }: HelpTipProps) {
+export function HelpTip({ title, titleExtra, children }: HelpTipProps) {
   const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
   const [isSuppressed, setIsSuppressed] = useState(false);
@@ -27,6 +28,16 @@ export function HelpTip({ title, children }: HelpTipProps) {
     if (tipTimerRef.current) window.clearTimeout(tipTimerRef.current);
     tipTimerRef.current = window.setTimeout(() => setIsSuppressed(false), 500);
   }
+
+  const baseTitle = title ?? t('ui.common.help', 'Help');
+  const modalTitle = titleExtra ? (
+    <span className="inline-flex flex-wrap items-baseline gap-x-2">
+      <span>{baseTitle}</span>
+      {titleExtra}
+    </span>
+  ) : (
+    baseTitle
+  );
 
   return (
     <div
@@ -60,7 +71,7 @@ export function HelpTip({ title, children }: HelpTipProps) {
         isOpen={isOpen}
         setOpen={setIsOpen}
         onClose={onClose}
-        title={title ?? t('ui.common.help', 'Help')}
+        title={modalTitle}
         variant="compact"
       >
         <div className="ui-prose-muted">{children}</div>

--- a/src/components/NumberField.tsx
+++ b/src/components/NumberField.tsx
@@ -6,6 +6,7 @@ interface NumberFieldProps {
   className?: string;
   title: string;
   description?: string;
+  flag?: number;
   value: number;
   placeholder?: string;
   min?: number;
@@ -19,6 +20,7 @@ export function NumberField({
   className,
   title,
   description,
+  flag,
   value,
   placeholder,
   min,
@@ -32,6 +34,7 @@ export function NumberField({
       className={className}
       title={title}
       description={description}
+      flag={flag}
       label
     >
       <NumberInput


### PR DESCRIPTION
<img width="764" height="257" alt="image" src="https://github.com/user-attachments/assets/e467a878-a085-483c-95d8-7ae55248207c" />

(also fix checkbox flags showing "Help" in the popup instead of the flag name)