### PR TITLE
fix: correct flag labels and typos per issue #133

### DIFF
--- a/src/data/flag-bitfields.ts
+++ b/src/data/flag-bitfields.ts
@@ -524,7 +524,7 @@ export const FLAG_BITFIELDS_META: Record<
   [FLAG_BITFIELDS.PLATFORMING_INTRO_ATTACK_WALL]: {
     parent: FLAGS.PLATFORMING_INTRO_FLAGS,
     index: 8,
-    displayName: 'Attack wall',
+    displayName: 'Attacked wall',
     description:
       'Whether you attacked a wall, prompting Ralsei to tell you how to jump.',
     valueType: 'boolean',

--- a/src/data/flags.ts
+++ b/src/data/flags.ts
@@ -31,8 +31,8 @@ const ALPHABET: Record<number, string> = {
 
 const ENCOUNTER_OUTCOMES: Record<number, string> = {
   0: 'Default state',
-  1: 'Violenced (includes SnowGrave)',
-  2: 'Spared',
+  1: 'Spared',
+  2: 'Violenced (includes SnowGrave)',
   3: 'Pacified',
   4: 'In combat (Ch. 1)',
   5: 'Violenced by uncontrolled Susie (unused in demo due to a bug)',
@@ -10168,7 +10168,7 @@ export const FLAGS_META: Partial<Record<FlagIndex, FlagProperties>> = {
   },
   [FLAGS.FRIEND_INTERACTED]: {
     displayName: 'Acted on Friend',
-    description: 'Whether you acted on and was damaged by Friend in Chapter 5.',
+    description: 'Whether you acted on and were damaged by Friend in Chapter 5.',
     valueType: 'boolean',
   },
   [FLAGS.PLATMODE_JUMP_COUNT]: {


### PR DESCRIPTION
## Summary
Fixes 3 issues from issue #133:

1. **ENCOUNTER_OUTCOMES labels 1 and 2 swapped**: Per the issue reporter's Deltarune save data analysis, the Spamton NEO encounter outcome labels were backwards (1=Spared in actual game data, not Violenced). Swapped labels 1 and 2 in the ENCOUNTER_OUTCOMES map.

2. **FRIEND_INTERACTED grammar fix**: 'was damaged' -> 'were damaged' (subject is plural 'you')

3. **PLATFORMING_INTRO_ATTACK_WALL displayName**: 'Attack wall' -> 'Attacked wall' (displayName now matches past-tense description)

## Testing
- TypeScript syntax verified (no errors)
- No logic changes, only label/description corrections
- Matches fix description in issue #133

## Files changed
- src/data/flags.ts (ENCOUNTER_OUTCOMES swap + FRIEND_INTERACTED grammar)
- src/data/flag-bitfields.ts (Attack wall -> Attacked wall)